### PR TITLE
Only perform a port-validity check on service node addresses for

### DIFF
--- a/director/etcd.go
+++ b/director/etcd.go
@@ -169,7 +169,7 @@ func (b *etcdDirector) processServiceNode(e *etcdParsedNode, add bool) {
 	}
 
 	// Check for a valid port.
-	if addr.Port <= 0 {
+	if add && addr.Port <= 0 {
 		log.WithFields(e.fields()).WithField("port", addr.Port).Error("invalid port")
 		return
 	}


### PR DESCRIPTION
additive actions.

Addresses newsdev/promise#1.
